### PR TITLE
Add success message, build check, and refactor Main method

### DIFF
--- a/src/EntityCore.Tools/CodeGenerator.cs
+++ b/src/EntityCore.Tools/CodeGenerator.cs
@@ -16,6 +16,10 @@ namespace EntityCore.Tools
 
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
             File.WriteAllText(outputPath, serviceCode);
+
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"Service for '{entityName}' entity generated successfully.");
+            Console.ResetColor();
         }
 
         private string GenerateServiceCode(string dllPath, string entityName)


### PR DESCRIPTION
Introduce a new feature in `CodeGenerator.cs` to display a success message in green text after generating a service for an entity. Add namespace declaration and encapsulate `Main` method within an `public class Program` in `Program.cs`. Implement `EnsureBuild` method to build the project and handle build failures with error messages in red. Refactor `Main` method to call `EnsureBuild` before generating the service and improve overall readability and maintainability.