### PR TITLE
Interface qo'shim qisqacha:

### DIFF
--- a/src/EntityCore.Tools/Logic/CRUD/Add.cs
+++ b/src/EntityCore.Tools/Logic/CRUD/Add.cs
@@ -5,7 +5,16 @@ namespace EntityCore.Tools
 {
     public partial class CodeGenerator
     {
-        private static MethodDeclarationSyntax GenerateAddMethod(string entityName, string dbContextVariableName)
+        private MemberDeclarationSyntax GenerateAddMethodDecleration(string entityName)
+        {
+            return SyntaxFactory.MethodDeclaration(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Task"))
+                    .AddTypeArgumentListArguments(SyntaxFactory.ParseTypeName(entityName)), "AddAsync")
+                    .AddParameterListParameters(SyntaxFactory.Parameter(SyntaxFactory.Identifier("entity"))
+                        .WithType(SyntaxFactory.ParseTypeName(entityName)))
+                    .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+        }
+
+        private static MethodDeclarationSyntax GenerateAddMethodImplementation(string entityName, string dbContextVariableName)
         {
             return SyntaxFactory.MethodDeclaration(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Task"))
                                 .AddTypeArgumentListArguments(SyntaxFactory.ParseTypeName(entityName)), "AddAsync")

--- a/src/EntityCore.Tools/Logic/CRUD/Delete.cs
+++ b/src/EntityCore.Tools/Logic/CRUD/Delete.cs
@@ -6,7 +6,17 @@ namespace EntityCore.Tools
 {
     public partial class CodeGenerator
     {
-        private static MethodDeclarationSyntax GenerateDeleteMothod(string entityName, string dbContextVariableName, PropertyInfo primaryKey)
+        private static MethodDeclarationSyntax GenerateDeleteMethodDeclaration(string entityName, PropertyInfo primaryKey)
+        {
+            return SyntaxFactory.MethodDeclaration(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Task"))
+                                .AddTypeArgumentListArguments(SyntaxFactory.ParseTypeName(entityName)), "DeleteAsync")
+                                .AddParameterListParameters(SyntaxFactory.Parameter(SyntaxFactory.Identifier("id"))
+                                    .WithType(SyntaxFactory.ParseTypeName(primaryKey.PropertyType.ToCSharpTypeName())))
+                                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)
+                                );
+        }
+
+        private static MethodDeclarationSyntax GenerateDeleteMethodImplementation(string entityName, string dbContextVariableName, PropertyInfo primaryKey)
         {
             return SyntaxFactory.MethodDeclaration(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Task"))
                                 .AddTypeArgumentListArguments(SyntaxFactory.ParseTypeName(entityName)), "DeleteAsync")

--- a/src/EntityCore.Tools/Logic/CRUD/GetAll.cs
+++ b/src/EntityCore.Tools/Logic/CRUD/GetAll.cs
@@ -5,7 +5,15 @@ namespace EntityCore.Tools
 {
     public partial class CodeGenerator
     {
-        private static MethodDeclarationSyntax GenerateGetAllMethod(string entityName, string dbContextVariableName)
+        private static MethodDeclarationSyntax GenerateGetAllMethodDeclaration(string entityName)
+        {
+            return SyntaxFactory.MethodDeclaration(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Task"))
+                                .AddTypeArgumentListArguments(SyntaxFactory.ParseTypeName($"List<{entityName}>")), "GetAllAsync")
+                                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)
+                                );
+        }
+
+        private static MethodDeclarationSyntax GenerateGetAllMethodImplementation(string entityName, string dbContextVariableName)
         {
             return SyntaxFactory.MethodDeclaration(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Task"))
                                 .AddTypeArgumentListArguments(SyntaxFactory.ParseTypeName($"List<{entityName}>")), "GetAllAsync")

--- a/src/EntityCore.Tools/Logic/CRUD/GetById.cs
+++ b/src/EntityCore.Tools/Logic/CRUD/GetById.cs
@@ -6,7 +6,17 @@ namespace EntityCore.Tools
 {
     public partial class CodeGenerator
     {
-        private static MethodDeclarationSyntax GenerateGetByIdMethod(string entityName, string dbContextVariableName, PropertyInfo primaryKey)
+        private static MethodDeclarationSyntax GenerateGetByIdMethodDeclaration(string entityName, PropertyInfo primaryKey)
+        {
+            return SyntaxFactory.MethodDeclaration(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Task"))
+                                .AddTypeArgumentListArguments(SyntaxFactory.ParseTypeName(entityName)), "GetByIdAsync")
+                                .AddParameterListParameters(SyntaxFactory.Parameter(SyntaxFactory.Identifier("id"))
+                                    .WithType(SyntaxFactory.ParseTypeName(primaryKey.PropertyType.ToCSharpTypeName())))
+                                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)
+                                );
+        }
+
+        private static MethodDeclarationSyntax GenerateGetByIdMethodImplementation(string entityName, string dbContextVariableName, PropertyInfo primaryKey)
         {
             return SyntaxFactory.MethodDeclaration(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Task"))
                                 .AddTypeArgumentListArguments(SyntaxFactory.ParseTypeName(entityName)), "GetByIdAsync")

--- a/src/EntityCore.Tools/Logic/CRUD/Update.cs
+++ b/src/EntityCore.Tools/Logic/CRUD/Update.cs
@@ -6,7 +6,19 @@ namespace EntityCore.Tools
 {
     public partial class CodeGenerator
     {
-        private static MethodDeclarationSyntax GenerateUpdateMethod(string entityName, string dbContextVariableName, PropertyInfo primaryKey)
+        private static MethodDeclarationSyntax GenerateUpdateMethodDeclaration(string entityName, PropertyInfo primaryKey)
+        {
+            return SyntaxFactory.MethodDeclaration(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Task"))
+                                .AddTypeArgumentListArguments(SyntaxFactory.ParseTypeName(entityName)), "UpdateAsync")
+                                .AddParameterListParameters(SyntaxFactory.Parameter(SyntaxFactory.Identifier("id"))
+                                    .WithType(SyntaxFactory.ParseTypeName(primaryKey.PropertyType.ToCSharpTypeName())))
+                                .AddParameterListParameters(SyntaxFactory.Parameter(SyntaxFactory.Identifier("entity"))
+                                    .WithType(SyntaxFactory.ParseTypeName(entityName)))
+                                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)
+                                );
+        }
+
+        private static MethodDeclarationSyntax GenerateUpdateMethodImplementation(string entityName, string dbContextVariableName, PropertyInfo primaryKey)
         {
             return SyntaxFactory.MethodDeclaration(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Task"))
                                 .AddTypeArgumentListArguments(SyntaxFactory.ParseTypeName(entityName)), "UpdateAsync")


### PR DESCRIPTION
Refactor service code generation in CodeGenerator.cs

Refactored `GenerateService` to separate service implementation and declaration code generation. Removed `GenerateServiceCode` and replaced it with `GenerateServiceDeclarationCode` and `GenerateServiceImplementationCode`. Moved and modified `GenerateUsings` for reuse. Added methods for generating service interface method declarations and corresponding implementation methods. Updated `GetClassDeclaration` to use new method names. Re-added `GenerateUsings` with minor changes.